### PR TITLE
warn against automatically using nightly features

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -81,6 +81,15 @@ impl Channel {
     /// Returns `true` if this channel supports feature flags. In other words,
     /// returns `true` if the channel is either `dev` or `nightly`.
     ///
+    /// Note that it is generally a bad idea to automatically use a feature just
+    /// because it is supported. Nightly features are unstable by their very nature,
+    /// so a crate that automatically makes use of nightly features is prone to
+    /// breakage: if the feature changes in rustc in an incompatible way, then a
+    /// crate that automatically uses the feature will fail to build for everyone
+    /// using nightly! The recommended practice is to make using nightly features
+    /// opt-in (e.g. via a crate feature), so that people only experience broken
+    /// builds when they explicitly asked for a nightly feature.
+    ///
     /// # Example
     ///
     /// ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,15 @@
 //!   };
 //!   ```
 //!
+//!   Note that it is generally a bad idea to automatically use a feature just
+//!   because it is supported. Nightly features are unstable by their very nature,
+//!   so a crate that automatically makes use of nightly features is prone to
+//!   breakage: if the feature changes in rustc in an incompatible way, then a
+//!   crate that automatically uses the feature will fail to build for everyone
+//!   using nightly! The recommended practice is to make using nightly features
+//!   opt-in (e.g. via a crate feature), so that people only experience broken
+//!   builds when they explicitly asked for a nightly feature.
+//!
 //! * Check that the running compiler supports a specific feature:
 //!
 //!   ```rust
@@ -57,14 +66,8 @@
 //!   }
 //!   ```
 //!
-//!   Note that it is generally a bad idea to automatically use a feature just
-//!   because it is supported. Nightly features are unstable by their very nature,
-//!   so a crate that automatically makes use of nightly features is prone to
-//!   breakage: if the feature changes in rustc in an incompatible way, then a
-//!   crate that automatically uses the feature will fail to build for everyone
-//!   using nightly! The recommended practice is to make using nightly features
-//!   opt-in (e.g. via a crate feature), so that people only experience broken
-//!   builds when they explicitly asked for a nightly feature.
+//!   The note above about automatic feature detection also applies here:
+//!   it is almost always a bad idea to do this.
 //!
 //! * Check that the running compiler is on the stable channel:
 //!
@@ -272,6 +275,15 @@ pub fn is_exact_version(version: &str) -> Option<bool> {
 /// check. That is, this function _does not_ check whether a _specific_ feature
 /// is supported, but instead whether features are supported at all. To check
 /// for support for a specific feature, use [`supports_feature()`].
+///
+/// Note that it is generally a bad idea to automatically use a feature just
+/// because it is supported. Nightly features are unstable by their very nature,
+/// so a crate that automatically makes use of nightly features is prone to
+/// breakage: if the feature changes in rustc in an incompatible way, then a
+/// crate that automatically uses the feature will fail to build for everyone
+/// using nightly! The recommended practice is to make using nightly features
+/// opt-in (e.g. via a crate feature), so that people only experience broken
+/// builds when they explicitly asked for a nightly feature.
 ///
 /// If the version could not be determined, returns `None`. Otherwise returns
 /// `true` if the running version supports feature flags and `false` otherwise.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,15 @@
 //!   }
 //!   ```
 //!
+//!   Note that it is generally a bad idea to automatically use a feature just
+//!   because it is supported. Nightly features are unstable by their very nature,
+//!   so a crate that automatically makes use of nightly features is prone to
+//!   breakage: if the feature changes in rustc in an incompatible way, then a
+//!   crate that automatically uses the feature will fail to build for everyone
+//!   using nightly! The recommended practice is to make using nightly features
+//!   opt-in (e.g. via a crate feature), so that people only experience broken
+//!   builds when they explicitly asked for a nightly feature.
+//!
 //! * Check that the running compiler is on the stable channel:
 //!
 //!   ```rust
@@ -276,6 +285,15 @@ pub fn is_feature_flaggable() -> Option<bool> {
 /// feature is not disabled via exclusion in `allow-features` via `RUSTFLAGS` or
 /// `CARGO_ENCODED_RUSTFLAGS`. If the version could not be determined, returns
 /// `None`.
+///
+/// Note that it is generally a bad idea to automatically use a feature just
+/// because it is supported. Nightly features are unstable by their very nature,
+/// so a crate that automatically makes use of nightly features is prone to
+/// breakage: if the feature changes in rustc in an incompatible way, then a
+/// crate that automatically uses the feature will fail to build for everyone
+/// using nightly! The recommended practice is to make using nightly features
+/// opt-in (e.g. via a crate feature), so that people only experience broken
+/// builds when they explicitly asked for a nightly feature.
 ///
 /// # Example
 ///


### PR DESCRIPTION
See https://github.com/tkaitchuck/aHash/issues/200 for an issue caused by using `version_check::supports_feature` without considering the consequences.

IMO `supports_feature` should be removed entirely, but maybe there are ways to use it that are not as fragile?